### PR TITLE
Fix #2566 register constructor mappers

### DIFF
--- a/deployment/src/main/java/org/jdbi/quarkus/deployment/JdbiAnnotationsQuarkusProcessor.java
+++ b/deployment/src/main/java/org/jdbi/quarkus/deployment/JdbiAnnotationsQuarkusProcessor.java
@@ -20,8 +20,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.jboss.jandex.Type;
-import org.jdbi.v3.sqlobject.config.RegisterConstructorMappers;
 
 class JdbiAnnotationsQuarkusProcessor {
 

--- a/integration-tests/src/main/java/io/quarkiverse/jdbi/it/JdbiResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/jdbi/it/JdbiResource.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
 import org.jdbi.v3.examples.CustomSqlArrayType;
+import org.jdbi.v3.examples.RegisterConstructorMappers;
 import org.jdbi.v3.examples.ResultsAsMultimap;
 
 @Path("/jdbi")
@@ -32,6 +33,7 @@ public class JdbiResource {
     public String hello() throws Exception {
         CustomSqlArrayType.main();
         ResultsAsMultimap.main();
+        RegisterConstructorMappers.main();
 
         return "OK";
     }

--- a/integration-tests/src/main/java/org/jdbi/v3/examples/RegisterConstructorMappers.java
+++ b/integration-tests/src/main/java/org/jdbi/v3/examples/RegisterConstructorMappers.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdbi.v3.examples;
+
+import static org.jdbi.v3.examples.order.OrderSupport.withOrders;
+
+import java.util.List;
+import java.util.stream.Collector;
+
+import org.jdbi.v3.examples.order.Order;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+
+import com.google.common.collect.Multimap;
+
+/**
+ * Map a list or results based on an attribute onto a map. Multiple results can map on the same attribute, so using a Guava
+ * Multimap (which is a map of lists)
+ * solves that problem.
+ * <p>
+ * Also shows the use of {@link org.jdbi.v3.core.result.ResultIterable#collect(Collector)}.
+ */
+@SuppressWarnings({ "PMD.SystemPrintln" })
+public final class RegisterConstructorMappers {
+
+    private RegisterConstructorMappers() {
+        throw new AssertionError("RegisterConstructorMappers can not be instantiated");
+    }
+
+    public static void main(String... args) throws Exception {
+        withOrders(jdbi -> {
+
+            var orders = jdbi.withExtension(Dao.class, dao -> dao.findOrders());
+
+            // display results
+            orders.forEach(o -> System.out.printf("%d - %s%n", o.getId(), o.toString()));
+        });
+    }
+
+    interface Dao {
+
+        @SqlQuery("SELECT * from orders LIMIT 5")
+        @RegisterConstructorMapper(Order.class)
+        @RegisterConstructorMapper(User.class)
+        List<Order> findOrders();
+    }
+
+    class User {
+    }
+}

--- a/integration-tests/src/main/java/org/jdbi/v3/examples/order/OrderSupport.java
+++ b/integration-tests/src/main/java/org/jdbi/v3/examples/order/OrderSupport.java
@@ -39,7 +39,8 @@ public final class OrderSupport {
 
     public static void createTables(Jdbi jdbi) {
         jdbi.withHandle(
-                handle -> handle.execute("CREATE TABLE IF NOT EXISTS orders (id INT, user_id INT, comment VARCHAR, address VARCHAR)"));
+                handle -> handle
+                        .execute("CREATE TABLE IF NOT EXISTS orders (id INT, user_id INT, comment VARCHAR, address VARCHAR)"));
     }
 
     public static void populateOrders(Jdbi jdbi, int orderCount, int userIdCount) {

--- a/integration-tests/src/main/java/org/jdbi/v3/examples/order/OrderSupport.java
+++ b/integration-tests/src/main/java/org/jdbi/v3/examples/order/OrderSupport.java
@@ -39,7 +39,7 @@ public final class OrderSupport {
 
     public static void createTables(Jdbi jdbi) {
         jdbi.withHandle(
-                handle -> handle.execute("CREATE TABLE orders (id INT, user_id INT, comment VARCHAR, address VARCHAR)"));
+                handle -> handle.execute("CREATE TABLE IF NOT EXISTS orders (id INT, user_id INT, comment VARCHAR, address VARCHAR)"));
     }
 
     public static void populateOrders(Jdbi jdbi, int orderCount, int userIdCount) {
@@ -47,6 +47,8 @@ public final class OrderSupport {
 
         jdbi.withHandle(
                 handle -> {
+                    handle.createUpdate("TRUNCATE orders").execute();
+
                     for (int j = 0; j < userIdCount; j++) {
                         int userId = RANDOM.nextInt(10_000);
                         for (int i = 0; i < orderCount; i++) {


### PR DESCRIPTION
Fix for issue #2566 with the `@RegisterConstructorMappers` annotation.

Updated construction of `ReflectiveClassBuildItem` item since the used constructors are all deprecated.
Using the recommended `builder(...)` method.