### PR TITLE
Add description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
   <version>999-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Quarkus Jdbi - Parent</name>
+  <description>Jdbi provides convenient, idiomatic access to relational data in Java. This extension makes it possible to use JDBI in native executables.</description>
   <modules>
     <module>deployment</module>
     <module>runtime</module>


### PR DESCRIPTION
Without a description, extensions inherit the generic description from the parent pom. The description is displayed on https://quarkus.io/extensions/io.quarkiverse.jdbi/quarkus-jdbi/. 

<img width="242" alt="image" src="https://github.com/user-attachments/assets/b1f399d6-9858-4789-82be-2c71a48bc96f">
