### PR TITLE
Add extension metadata file to fill in name

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,1 @@
+name: Jdbi


### PR DESCRIPTION
If an extension doesn't specify a name in the extension metadata file, it will be filled in from the pom. That gives something like this:

<img width="243" alt="image" src="https://github.com/user-attachments/assets/8c37724c-4fd6-43be-b3b1-0645a6909394">

It's better than nothing, but it's not ideal, because "Quarkus" in the name is a bit redundant, and the "Runtime" in the name isn't correct. I've made a metadata file, which will be useful for holding other metadata, and filled in a name.