### PR TITLE
Bump JDBI to 3.49.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.21.1</quarkus.version>
-    <jdbi3.version>3.42.0</jdbi3.version>
+    <jdbi3.version>3.49.0</jdbi3.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This PR bumps `jdbi3` to the latest version, [`3.49.0`](https://github.com/jdbi/jdbi/releases/tag/v3.49.0).